### PR TITLE
increase the maximum heap size limit to 2GB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,4 @@ android.nonTransitiveRClass=true
 org.gradle.unsafe.configuration-cache=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.jvmargs=-Xmx2g


### PR DESCRIPTION
This PR increases the max heap size limit to 2gb to allow builds on Dashwave.
Here is a preview of build running on Dashwave Workspaces.

<img width="1257" alt="image" src="https://github.com/user-attachments/assets/22570432-eeeb-44c8-a430-3ba8d879f321">
